### PR TITLE
Use less explicit type checking when creating rdf

### DIFF
--- a/foist/app.py
+++ b/foist/app.py
@@ -13,6 +13,12 @@ import requests
 
 from foist.namespaces import BIBO, DCTERMS, DCTYPE, LOCAL, MODS, MSL, PCDM, RDF
 
+
+try:
+    basestring
+except NameError:
+    basestring = (str, bytes)
+
 log = logging.getLogger(__name__)
 
 base_mets_search = './mets:dmdSec/*/*/*/mods:'
@@ -195,28 +201,24 @@ class Thesis(object):
         m = rdflib.Graph()
         s = rdflib.URIRef('')
 
-        def _add_metadata_field(p, obj, obj_type='string'):
-            if obj is None:
-                o = rdflib.Literal('None')
-                m.add((s, p, o))
-            elif obj is True:
-                o = rdflib.Literal('True')
-                m.add((s, p, o))
-            elif type(obj) == list:
-                for i in obj:
-                    o = _create_rdf_obj(i, obj_type)
-                    m.add((s, p, o))
-            else:
-                o = _create_rdf_obj(obj, obj_type)
+        def _add_metadata_field(p, obj, is_uri=False):
+            if not isinstance(obj, basestring):
+                try:
+                    for i in obj:
+                        o = _create_rdf_obj(i, is_uri)
+                        m.add((s, p, o))
+                    return
+                except TypeError:
+                    # not iterable
+                    pass
+            if obj is not None:
+                o = _create_rdf_obj(obj, is_uri)
                 m.add((s, p, o))
 
-        def _create_rdf_obj(obj, obj_type):
-            if obj_type == 'string':
-                o = rdflib.Literal(obj)
-                return o
-            elif obj_type == 'uri':
-                o = rdflib.URIRef(obj)
-                return o
+        def _create_rdf_obj(obj, is_uri):
+            if is_uri:
+                return rdflib.URIRef(obj)
+            return rdflib.Literal(obj)
 
         # Bind prefixes to metadata graph
         m.bind('bibo', BIBO)
@@ -235,20 +237,20 @@ class Thesis(object):
             _add_metadata_field(DCTERMS.title, self.alt_title)
         _add_metadata_field(DCTERMS.creator, self.author)
         _add_metadata_field(DCTERMS.dateCopyrighted, self.copyright_date)
-        _add_metadata_field(DCTERMS.type, self.dc_type, obj_type='uri')
+        _add_metadata_field(DCTERMS.type, self.dc_type, is_uri='uri')
         _add_metadata_field(MSL.degreeGrantedForCompletion,
                             self.degree)
         _add_metadata_field(LOCAL.degree_statement, self.degree_statement)
         _add_metadata_field(MSL.associatedDepartment, self.department)
         _add_metadata_field(LOCAL.encoded_text, self.encoded_text)
-        _add_metadata_field(BIBO.handle, self.handle, obj_type='uri')
+        _add_metadata_field(BIBO.handle, self.handle, is_uri='uri')
         _add_metadata_field(LOCAL.handle_part, self.handle_part)
         _add_metadata_field(DCTERMS.dateIssued, self.issue_date)
         _add_metadata_field(LOCAL.ligature_errors, self.ligatures)
         _add_metadata_field(LOCAL.no_full_text, self.no_full_text)
         _add_metadata_field(MODS.note, self.notes)
         _add_metadata_field(DCTERMS.publisher, self.publisher)
-        _add_metadata_field(RDF.type, self.rdf_type, obj_type='uri')
+        _add_metadata_field(RDF.type, self.rdf_type, is_uri='uri')
         _add_metadata_field(DCTERMS.rights, self.rights_statement)
         _add_metadata_field(DCTERMS.title, self.title)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -99,8 +99,7 @@ def test_thesis_get_metadata_returns_turtle(tmpdir, xml, text_errors):
     assert b'bibo:Thesis' in m
     assert b'dcterms:type dctype:Text' in m
     assert b'dcterms:title "Alternative Title."' in m
-    assert b'local:ligature_errors "None"' in m
-    assert b'local:encoded_text "True"' in m
+    assert b'local:encoded_text true' in m
     assert b'bibo:handle <http://hdl.handle.net/1721.1/39208>' in m
     assert b'msl:degreeGrantedForCompletion "M.B.A."' in m
     assert b'"S.M."' in m
@@ -110,6 +109,15 @@ def test_thesis_get_metadata_returns_turtle(tmpdir, xml, text_errors):
     assert (b'msl:associatedDepartment "Computation for Design and '
             b'Optimization"' in m)
     assert b'local:handle_part "39208"' in m
+
+
+def test_get_metadata_removes_fields_with_none(xml, text_errors):
+    mets = ET.parse(xml).getroot()
+    errors = parse_text_encoding_errors(text_errors).get('thesis')
+    t = Thesis('thesis', mets, 'Computation for Design and Optimization',
+               errors)
+    m = t.get_metadata()
+    assert b'local:ligature_errors' not in m
 
 
 def test_thesis_handles_missing_metadata_fields(tmpdir, xml_missing_fields,


### PR DESCRIPTION
This changes `_add_metadata_field` to support a broader range of valid
types. It should now support all list-like iterables, not just lists.
Statements which would have had `None` as their object are now left out
of the graph. Boolean values are passed directly to rdflib which will
cast to XML Schema datatype boolean.